### PR TITLE
Sync programme vaccination coverage scheme with DHIS2 Child Vaccination program

### DIFF
--- a/jobs/load-teis.js
+++ b/jobs/load-teis.js
@@ -17,6 +17,7 @@ fn(state => {
 
       const oclMapping = {
         PARN: 'GMfuAqBFS1g',
+        'Programme Vaccination': 'GMfuAqBFS1g',
         'Santé Maternelle': 'wBUDpZSS4Bh',
       };
 


### PR DESCRIPTION
For the demo we'd like to sync claims that have an insurance coverage display value of `Programme Vaccination` to the Child Vaccination program in addition to `PARN` claims @mtuchi